### PR TITLE
Location-agnostic redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,17 @@
 # disable automatic filename re-mapping based on languages (breaks RewriteCond)
 Options -MultiViews
 
-# redirect all api/v1/ requests to api.php
+# detect our base directory (probably yadda/yadda/api/v1 or something)
+# (Stack Overflow rocks: http://stackoverflow.com/a/21027742)
+RewriteCond %{ENV:URI} ^$
+RewriteRule ^(.*)$ - [ENV=URI:$1]
+
+RewriteCond %{ENV:BASE} ^$
+RewriteCond %{ENV:URI}::%{REQUEST_URI} ^(.*)::(.*?)\1$
+RewriteRule ^ - [ENV=BASE:%2]
+
+# redirect all requests to api.php
 RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule api/v1/(.*)$ %{CONTEXT_PREFIX}/api.php/$1 [QSA,NC,L]
+RewriteRule (.*)$ %{ENV:BASE}api.php/$1 [QSA,NC,L]


### PR DESCRIPTION
It seems like it would be better not to assume that all APIs are version 1. ;) So… redirect all requests to the local `api.php` script.